### PR TITLE
feat(add-nx-dart-to-monorepo): make script more robust

### DIFF
--- a/e2e/add-nx-dart-to-monorepo-e2e/tests/add-nx-dart-to-monorepo.spec.ts
+++ b/e2e/add-nx-dart-to-monorepo-e2e/tests/add-nx-dart-to-monorepo.spec.ts
@@ -19,7 +19,7 @@ describe('add-nx-dart-to-monorepo', () => {
 
   it('does not throw', async () => {
     newNonNxWorkspace();
-    writePubspec('packages/a/pubspec.yaml', {
+    writePubspec('packages/a', {
       name: 'a',
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "dependencies": {
         "@nrwl/devkit": "14.1.7",
         "enquirer": "^2.3.6",
+        "globby": "^13.1.1",
         "ignore": "^5.2.0",
         "node-fetch": "^2.6.7",
         "strip-json-comments": "^3.1.1",
@@ -1350,6 +1351,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/@lerna/create/node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/@lerna/create/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -1363,6 +1380,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lerna/create/node_modules/yargs-parser": {
@@ -1924,6 +1961,42 @@
       },
       "engines": {
         "node": ">= 10.18.0"
+      }
+    },
+    "node_modules/@lerna/project/node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@lerna/project/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lerna/prompt": {
@@ -3436,6 +3509,42 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -4998,7 +5107,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -6389,20 +6497,18 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.1.tgz",
+      "integrity": "sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==",
       "dependencies": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
+        "fast-glob": "^3.2.11",
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6412,7 +6518,6 @@
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
       "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -6422,6 +6527,17 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -9960,7 +10076,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12323,7 +12438,7 @@
       }
     },
     "packages/add-nx-dart-to-monorepo": {
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "bin": {
         "add-nx-dart-to-monorepo": "bin/add-nx-dart-to-monorepo.js"
@@ -12331,15 +12446,15 @@
     },
     "packages/dart-parser": {
       "name": "@nx-dart/dart-parser",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT"
     },
     "packages/nx-dart": {
       "name": "@nx-dart/nx-dart",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@nx-dart/dart-parser": "^0.0.1",
+        "@nx-dart/dart-parser": "^0.1.0",
         "tslib": "^2.3.0"
       }
     }
@@ -13351,6 +13466,19 @@
         "yargs-parser": "20.2.4"
       },
       "dependencies": {
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -13361,6 +13489,20 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
           }
         },
         "yargs-parser": {
@@ -13847,6 +13989,35 @@
         "p-map": "^4.0.0",
         "resolve-from": "^5.0.0",
         "write-json-file": "^4.3.0"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        }
       }
     },
     "@lerna/prompt": {
@@ -14432,7 +14603,7 @@
     "@nx-dart/nx-dart": {
       "version": "file:packages/nx-dart",
       "requires": {
-        "@nx-dart/dart-parser": "^0.0.1",
+        "@nx-dart/dart-parser": "^0.1.0",
         "tslib": "^2.3.0"
       }
     },
@@ -14999,6 +15170,33 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -16188,7 +16386,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
       }
@@ -17260,24 +17457,21 @@
       "dev": true
     },
     "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.1.tgz",
+      "integrity": "sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==",
       "requires": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
+        "fast-glob": "^3.2.11",
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "dependencies": {
         "fast-glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
           "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-          "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
@@ -17285,6 +17479,11 @@
             "merge2": "^1.3.0",
             "micromatch": "^4.0.4"
           }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
         }
       }
     },
@@ -20013,8 +20212,7 @@
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@nrwl/devkit": "14.1.7",
         "enquirer": "^2.3.6",
         "globby": "^13.1.1",
-        "ignore": "^5.2.0",
         "node-fetch": "^2.6.7",
         "strip-json-comments": "^3.1.1",
         "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@nrwl/devkit": "14.1.7",
     "enquirer": "^2.3.6",
     "globby": "^13.1.1",
-    "ignore": "^5.2.0",
     "node-fetch": "^2.6.7",
     "strip-json-comments": "^3.1.1",
     "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@nrwl/devkit": "14.1.7",
     "enquirer": "^2.3.6",
+    "globby": "^13.1.1",
     "ignore": "^5.2.0",
     "node-fetch": "^2.6.7",
     "strip-json-comments": "^3.1.1",

--- a/packages/add-nx-dart-to-monorepo/project.json
+++ b/packages/add-nx-dart-to-monorepo/project.json
@@ -14,7 +14,8 @@
         "assets": [
           "packages/add-nx-dart-to-monorepo/*.md",
           "packages/add-nx-dart-to-monorepo/LICENSE",
-          "packages/add-nx-dart-to-monorepo/bin/add-nx-dart-to-monorepo.js"
+          "packages/add-nx-dart-to-monorepo/bin/add-nx-dart-to-monorepo.js",
+          "packages/add-nx-dart-to-monorepo/src/globby.js"
         ]
       }
     },

--- a/packages/add-nx-dart-to-monorepo/src/globby.d.ts
+++ b/packages/add-nx-dart-to-monorepo/src/globby.d.ts
@@ -1,0 +1,5 @@
+import { GitignoreOptions, GlobbyFilterFunction } from 'globby';
+
+export function isGitIgnored(
+  options?: GitignoreOptions
+): Promise<GlobbyFilterFunction>;

--- a/packages/add-nx-dart-to-monorepo/src/globby.js
+++ b/packages/add-nx-dart-to-monorepo/src/globby.js
@@ -1,0 +1,6 @@
+// Workaround to be able to use `globby` from TypeScript + CommonJS.
+// `globby` is only available as ESM, but dynamic imports are converted to `require` by TypeScript.
+
+exports.isGitIgnored = async function (options) {
+  return (await import('globby')).isGitIgnored(options);
+};

--- a/packages/add-nx-dart-to-monorepo/tsconfig.json
+++ b/packages/add-nx-dart-to-monorepo/tsconfig.json
@@ -7,7 +7,8 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "allowJs": true
   },
   "files": [],
   "include": [],

--- a/packages/add-nx-dart-to-monorepo/tsconfig.json
+++ b/packages/add-nx-dart-to-monorepo/tsconfig.json
@@ -7,8 +7,7 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "allowJs": true
+    "noFallthroughCasesInSwitch": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
- Handle nested .gitignore files.
- Don't crash when `add-package` fails for a discovered package.